### PR TITLE
Ft brownbag shuffle #14

### DIFF
--- a/src/App/BrownBag/Commands.elm
+++ b/src/App/BrownBag/Commands.elm
@@ -1,9 +1,10 @@
 module App.BrownBag.Commands exposing (..)
 
 import Http as H
-import HttpBuilder exposing (withExpect)
+import HttpBuilder exposing (withExpect, withJsonBody)
 import Json.Decode as Decode exposing (succeed, andThen, maybe)
 import Json.Decode.Extra exposing ((|:))
+import Json.Encode as Encode
 import Common.Utils.Http as Http
 import App.Auth.Models exposing (Token)
 import App.BrownBag.Messages exposing (Msg(..))
@@ -67,3 +68,21 @@ status s =
 
             _ ->
                 NotDone
+
+
+shuffleUrl : String
+shuffleUrl =
+    baseUrl ++ "/shuffle/"
+
+
+shuffleDataEncoder : Encode.Value
+shuffleDataEncoder =
+    [ ( "type", Encode.string "brownbag" ) ] |> Encode.object
+
+
+shuffleBrownbag : Token -> Cmd Msg
+shuffleBrownbag =
+    HttpBuilder.send OnShuffleBrownbag
+        << withJsonBody shuffleDataEncoder
+        << withExpect (H.expectJson memberDecoder)
+        << Http.post shuffleUrl

--- a/src/App/BrownBag/Messages.elm
+++ b/src/App/BrownBag/Messages.elm
@@ -8,3 +8,4 @@ type Msg
     = OnFetchBrownBags (Result Http.Error (List BrownBag))
     | ListBrownBags
     | ShuffleBrownBag
+    | OnShuffleBrownbag (Result Http.Error BrownBag)

--- a/src/App/BrownBag/Messages.elm
+++ b/src/App/BrownBag/Messages.elm
@@ -2,6 +2,7 @@ module App.BrownBag.Messages exposing (..)
 
 import Http
 import App.BrownBag.Models exposing (BrownBag)
+import App.Auth.Models exposing (User)
 
 
 type Msg
@@ -9,3 +10,4 @@ type Msg
     | ListBrownBags
     | ShuffleBrownBag
     | OnShuffleBrownbag (Result Http.Error BrownBag)
+    | OnFetchUndone (Result Http.Error (List User))

--- a/src/App/BrownBag/Models.elm
+++ b/src/App/BrownBag/Models.elm
@@ -15,3 +15,14 @@ type alias BrownBag =
     , status : Status
     , user : User
     }
+
+
+type alias BrownbagModel =
+    { loading : Bool
+    , brownbags : List BrownBag
+    }
+
+
+initialModel : BrownbagModel
+initialModel =
+    BrownbagModel False []

--- a/src/App/BrownBag/Models.elm
+++ b/src/App/BrownBag/Models.elm
@@ -20,9 +20,10 @@ type alias BrownBag =
 type alias BrownbagModel =
     { loading : Bool
     , brownbags : List BrownBag
+    , undone : List User
     }
 
 
 initialModel : BrownbagModel
 initialModel =
-    BrownbagModel False []
+    BrownbagModel False [] []

--- a/src/App/BrownBag/Update.elm
+++ b/src/App/BrownBag/Update.elm
@@ -43,3 +43,13 @@ update msg ({ brownbag, authModel } as model) =
                     Debug.log "Error shuffling brownbag" err
             in
                 ( { brownbag | loading = False }, Cmd.none )
+
+        OnFetchUndone (Ok undoneUsers) ->
+            ( { brownbag | undone = undoneUsers }, Cmd.none )
+
+        OnFetchUndone (Err err) ->
+            let
+                _ =
+                    Debug.log "Error fetching undone users" err
+            in
+                ( brownbag, Cmd.none )

--- a/src/App/BrownBag/Update.elm
+++ b/src/App/BrownBag/Update.elm
@@ -2,25 +2,44 @@ module App.BrownBag.Update exposing (..)
 
 import Navigation
 import Routing.Route exposing (Route(..), reverse)
-import App.BrownBag.Models exposing (BrownBag)
+import Models exposing (Model)
+import App.BrownBag.Models exposing (BrownbagModel, BrownBag)
 import App.BrownBag.Messages exposing (Msg(..))
+import App.BrownBag.Commands exposing (shuffleBrownbag)
 
 
-update : Msg -> List BrownBag -> ( List BrownBag, Cmd Msg )
-update msg brownBags =
+update : Msg -> Model -> ( BrownbagModel, Cmd Msg )
+update msg ({ brownbag, authModel } as model) =
     case msg of
         ListBrownBags ->
-            ( brownBags, Navigation.newUrl (reverse BrownBagsRoute) )
+            ( brownbag, Navigation.newUrl (reverse BrownBagsRoute) )
 
         OnFetchBrownBags (Ok newBrownBags) ->
-            ( newBrownBags, Cmd.none )
+            ( { brownbag | brownbags = newBrownBags }, Cmd.none )
 
         OnFetchBrownBags (Err err) ->
             let
                 _ =
                     Debug.log "Error decoding brownBags" err
             in
-                ( brownBags, Cmd.none )
+                ( brownbag, Cmd.none )
 
-        _ ->
-            ( brownBags, Cmd.none )
+        ShuffleBrownBag ->
+            ( { brownbag | loading = True }, shuffleBrownbag authModel.token )
+
+        OnShuffleBrownbag (Ok newBrownbag) ->
+            let
+                newBrownbagModel =
+                    { brownbag
+                        | brownbags = newBrownbag :: brownbag.brownbags
+                        , loading = False
+                    }
+            in
+                ( newBrownbagModel, Cmd.none )
+
+        OnShuffleBrownbag (Err err) ->
+            let
+                _ =
+                    Debug.log "Error shuffling brownbag" err
+            in
+                ( { brownbag | loading = False }, Cmd.none )

--- a/src/App/BrownBag/View.elm
+++ b/src/App/BrownBag/View.elm
@@ -2,24 +2,25 @@ module App.BrownBag.View exposing (..)
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
 import Common.Utils exposing (brandUrl)
-import App.BrownBag.Messages exposing (Msg(..))
-import App.BrownBag.Models exposing (BrownBag, Status(..))
+import App.BrownBag.Messages exposing (Msg(ShuffleBrownBag))
+import App.BrownBag.Models exposing (BrownbagModel, BrownBag, Status(..))
 
 
-view : List BrownBag -> Html Msg
-view brownBags =
+view : BrownbagModel -> Html Msg
+view ({ brownbags } as model) =
     div [ class "columns brownbag" ]
-        [ feed brownBags
-        , undone brownBags
+        [ feed model
+        , undone brownbags
         ]
 
 
-feed : List BrownBag -> Html Msg
-feed brownBags =
+feed : BrownbagModel -> Html Msg
+feed ({ brownbags } as model) =
     div [ class "column is-two-thirds brownbag--feed" ]
-        [ upcoming brownBags
-        , previous brownBags
+        [ upcoming model
+        , previous brownbags
         ]
 
 
@@ -37,8 +38,8 @@ previous brownbags =
             ]
 
 
-upcoming : List BrownBag -> Html msg
-upcoming brownbags =
+upcoming : BrownbagModel -> Html Msg
+upcoming ({ brownbags } as model) =
     let
         maybeUpcoming =
             brownbags
@@ -54,24 +55,30 @@ upcoming brownbags =
                     ]
 
             Nothing ->
-                shuffleView
+                shuffleView model
 
 
-shuffleView : Html msg
-shuffleView =
-    div [ class "feed--card shuffle" ]
-        [ div [ class "shuffle--content" ]
-            [ h1 [] [ text "Next brown bag is almost up..." ]
-            , p [] [ text "30 Mar" ]
-            ]
-        , div [ class "shuffle--button" ]
-            [ button [ class "button is-info" ]
-                [ span [ class "icon" ]
-                    [ img [ src brandUrl ] [] ]
-                , span [] [ text "Shuffle" ]
+shuffleView : BrownbagModel -> Html Msg
+shuffleView { loading } =
+    let
+        shuffleButton =
+            if not loading then
+                button [ class "button is-info", onClick ShuffleBrownBag ]
+                    [ span [ class "icon" ]
+                        [ img [ src brandUrl ] [] ]
+                    , span [] [ text "Shuffle" ]
+                    ]
+            else
+                button [ class "button is-info is-loading" ] [ text "Loading" ]
+    in
+        div [ class "feed--card shuffle" ]
+            [ div [ class "shuffle--content" ]
+                [ h1 [] [ text "Next brown bag is almost up..." ]
+                , p [] [ text "30 Mar" ]
                 ]
+            , div [ class "shuffle--button" ]
+                [ shuffleButton ]
             ]
-        ]
 
 
 undone : List BrownBag -> Html msg

--- a/src/App/BrownBag/View.elm
+++ b/src/App/BrownBag/View.elm
@@ -6,21 +6,22 @@ import Html.Events exposing (onClick)
 import Common.Utils exposing (brandUrl)
 import App.BrownBag.Messages exposing (Msg(ShuffleBrownBag))
 import App.BrownBag.Models exposing (BrownbagModel, BrownBag, Status(..))
+import App.Auth.Models exposing (User)
 
 
 view : BrownbagModel -> Html Msg
-view ({ brownbags } as model) =
+view model =
     div [ class "columns brownbag" ]
         [ feed model
-        , undone brownbags
+        , viewUndone model.undone
         ]
 
 
 feed : BrownbagModel -> Html Msg
-feed ({ brownbags } as model) =
+feed model =
     div [ class "column is-two-thirds brownbag--feed" ]
         [ upcoming model
-        , previous brownbags
+        , previous model.brownbags
         ]
 
 
@@ -39,10 +40,10 @@ previous brownbags =
 
 
 upcoming : BrownbagModel -> Html Msg
-upcoming ({ brownbags } as model) =
+upcoming model =
     let
         maybeUpcoming =
-            brownbags
+            model.brownbags
                 |> List.filter (\p -> p.status == NextInLine)
                 |> List.head
     in
@@ -81,20 +82,30 @@ shuffleView { loading } =
             ]
 
 
-undone : List BrownBag -> Html msg
-undone brownBags =
-    brownBags
-        |> List.filter (\b -> b.status == NotDone)
-        |> viewUndone
-
-
-viewUndone : List BrownBag -> Html msg
-viewUndone brownBags =
+viewUndone : List User -> Html msg
+viewUndone users =
     div [ class "column is-one-third" ]
         [ div [ class "sidepanel" ]
             [ h1 [ class "title is-4 heading" ] [ text "Who's on the list" ]
-            , div [ class "sidepanel-list" ] [ brownbagsList brownBags ]
+            , div [ class "sidepanel-list" ] (undoneUsersList users)
             ]
+        ]
+
+
+undoneUsersList : List User -> List (Html msg)
+undoneUsersList =
+    List.map undone
+
+
+undone : User -> Html msg
+undone user =
+    div [ class "columns" ]
+        [ div [ class "column is-4" ]
+            [ figure [ class "image is-48x48" ]
+                [ img [ src user.profile.avatar, alt "avatar" ] [] ]
+            ]
+        , div [ class "column is-centered" ]
+            [ span [ class "subtitle is-6" ] [ text user.username ] ]
         ]
 
 

--- a/src/App/Update.elm
+++ b/src/App/Update.elm
@@ -8,7 +8,7 @@ import App.Auth.Update as Auth
 import App.Auth.Messages as AuthMessage
 import App.Auth.Ports as AuthPorts
 import App.BrownBag.Update as BrownBag
-import App.BrownBag.Commands exposing (getBrownBags)
+import App.BrownBag.Commands exposing (hydrateBrownbagData)
 import App.Hangouts.Update as Hangouts
 import App.Hangouts.Commands exposing (getHangouts)
 import App.SecretSanta.Update as SecretSanta
@@ -64,7 +64,7 @@ receiveToken token model =
             update (AuthMsg <| AuthMessage.ReceiveToken token) model
     in
         (newModel
-            ! [ (Cmd.map BrownBagMsg <| getBrownBags token)
+            ! [ (Cmd.map BrownBagMsg <| Cmd.batch <| hydrateBrownbagData token)
               , (Cmd.map HangoutsMsg <| getHangouts token)
               , (Cmd.map SecretSantaMsg <| getSecretSantas token)
               , cmd

--- a/src/App/Update.elm
+++ b/src/App/Update.elm
@@ -20,10 +20,14 @@ update msg model =
     case msg of
         BrownBagMsg subMsg ->
             let
-                ( updatedBrownBags, cmd ) =
-                    BrownBag.update subMsg model.brownBags
+                ( updatedBrownbagModel, cmd ) =
+                    BrownBag.update subMsg model
             in
-                ( { model | brownBags = updatedBrownBags }, Cmd.map BrownBagMsg cmd )
+                ( { model
+                    | brownbag = updatedBrownbagModel
+                  }
+                , Cmd.map BrownBagMsg cmd
+                )
 
         HangoutsMsg subMsg ->
             let

--- a/src/App/View.elm
+++ b/src/App/View.elm
@@ -31,7 +31,7 @@ currentView : Model -> Html Msg
 currentView model =
     case model.route of
         BrownBagsRoute ->
-            Html.map BrownBagMsg (BrownBag.view model.brownBags)
+            Html.map BrownBagMsg (BrownBag.view model.brownbag)
 
         HangoutsRoute ->
             Html.map HangoutsMsg (Hangouts.view model.hangoutModel)
@@ -41,4 +41,4 @@ currentView model =
 
         _ ->
             -- Default to showing brownBags for any other message.
-            Html.map BrownBagMsg (BrownBag.view model.brownBags)
+            Html.map BrownBagMsg (BrownBag.view model.brownbag)

--- a/src/Common/Utils.elm
+++ b/src/Common/Utils.elm
@@ -34,3 +34,8 @@ isJust aMaybe =
 
         Nothing ->
             False
+
+
+fork : (( a, b ) -> c) -> (d -> a) -> (d -> b) -> d -> c
+fork lastly first other =
+    (\x -> lastly ( first x, other x ))

--- a/src/Common/Utils.elm
+++ b/src/Common/Utils.elm
@@ -36,6 +36,9 @@ isJust aMaybe =
             False
 
 
+{-| Call a function using the results of calling two other functions with the
+    same argument.
+-}
 fork : (( a, b ) -> c) -> (d -> a) -> (d -> b) -> d -> c
-fork lastly first other =
-    (\x -> lastly ( first x, other x ))
+fork lastly first other x =
+    lastly ( first x, other x )

--- a/src/Models.elm
+++ b/src/Models.elm
@@ -1,6 +1,6 @@
 module Models exposing (..)
 
-import App.BrownBag.Models exposing (BrownBag)
+import App.BrownBag.Models as BrownbagModel
 import App.Hangouts.Models exposing (HangoutModel, hangoutInitialModel)
 import App.SecretSanta.Models exposing (SecretSanta)
 import App.Auth.Models
@@ -13,7 +13,7 @@ type alias Flags =
 
 
 type alias Model =
-    { brownBags : List BrownBag
+    { brownbag : BrownbagModel.BrownbagModel
     , hangoutModel : HangoutModel
     , secretSantas : List SecretSanta
     , route : Routing.Route
@@ -23,7 +23,7 @@ type alias Model =
 
 initialModel : Routing.Route -> Model
 initialModel route =
-    { brownBags = []
+    { brownbag = BrownbagModel.initialModel
     , hangoutModel = hangoutInitialModel
     , secretSantas = []
     , route = route


### PR DESCRIPTION
#### What does this PR do?
- Adds brownbag shuffling functionality
- Sets groundwork for displaying users who've not done brownbag.
#### Description of Task to be completed?
- Add functionality to shuffle brownbags.

#### How should this be manually tested?
- Ensure your backend server is running and the database has users but no user scheduled for the next brownbag. Start the server and navigate to [http://localhost:3000/brownbags](http://localhost:3000/brownbags). Click on the `shuffle` button.

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)
Before shuffle
<img width="1680" alt="screen shot 2017-04-12 at 18 18 00" src="https://cloud.githubusercontent.com/assets/17286899/24965549/04910da2-1fad-11e7-8fc7-69df87dc8277.png">

After shuffle
<img width="1680" alt="screen shot 2017-04-12 at 18 18 20" src="https://cloud.githubusercontent.com/assets/17286899/24965580/1f5fabe8-1fad-11e7-80aa-637ce170f170.png">

With Previous
<img width="1680" alt="screen shot 2017-04-12 at 18 19 46" src="https://cloud.githubusercontent.com/assets/17286899/24965596/2e3805de-1fad-11e7-9143-02c0e3bb6176.png">


#### Questions: